### PR TITLE
Update C++.sublime-syntax: add char8_t

### DIFF
--- a/C++/C++.sublime-syntax
+++ b/C++/C++.sublime-syntax
@@ -130,7 +130,7 @@ contexts:
       scope: keyword.operator.word.c++
 
   unique-types:
-    - match: \b(char16_t|char32_t|wchar_t|nullptr_t)\b
+    - match: \b(char8_t|char16_t|char32_t|wchar_t|nullptr_t)\b
       scope: storage.type.c++
     - match: \bclass\b
       scope: storage.type.c++


### PR DESCRIPTION
`char8_t` is a _C++20_ keyword. In the syntax file the `char8_t` will be processed in exactly the same way as the long-standing _C++11_ keywords: `char16_t`, `char32_t` and _C++98's_ `wchar_t`.
No additional actions required.

See also `char8_t` descriptions:
https://en.cppreference.com/w/cpp/language/types#Character_types
http://eel.is/c++draft/diff.cpp17.lex#3.1